### PR TITLE
Save quotes to MongoDB

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -11,6 +11,7 @@ import boqRoutes from './routes/boq.routes.js';
 import matchRoutes from './routes/match.routes.js';
 import priceRoutes from './routes/price.routes.js';
 import projectRoutes from './routes/project.routes.js';
+import quoteRoutes from './routes/quote.routes.js';
 import auth from './middlewares/auth.js';
 
 const app = express();
@@ -32,5 +33,6 @@ app.use('/api/boq', auth, boqRoutes);
 app.use('/api/match', auth, matchRoutes);
 app.use('/api/prices', auth, priceRoutes);
 app.use('/api/projects', auth, projectRoutes);
+app.use('/api/quotes', auth, quoteRoutes);
 
 export default app;

--- a/backend/src/models/Quote.js
+++ b/backend/src/models/Quote.js
@@ -1,0 +1,28 @@
+import mongoose from 'mongoose';
+
+const itemSchema = new mongoose.Schema(
+  {
+    id: Number,
+    description: String,
+    quantity: Number,
+    unit: String,
+    unitPrice: Number,
+    total: Number,
+  },
+  { _id: false }
+);
+
+const quoteSchema = new mongoose.Schema(
+  {
+    id: { type: String, required: true, unique: true, index: true },
+    client: { type: String, required: true },
+    project: { type: String, required: true },
+    value: { type: Number, required: true },
+    status: { type: String, default: 'pending' },
+    date: { type: Date, required: true },
+    items: [itemSchema],
+  },
+  { timestamps: true }
+);
+
+export default mongoose.model('Quote', quoteSchema);

--- a/backend/src/routes/quote.routes.js
+++ b/backend/src/routes/quote.routes.js
@@ -1,0 +1,68 @@
+import { Router } from 'express';
+import Quote from '../models/Quote.js';
+
+const router = Router();
+
+const memory = [];
+
+// List all quotes
+router.get('/', async (_req, res) => {
+  if (process.env.CONNECTION_STRING) {
+    const qs = await Quote.find().sort({ date: -1 }).lean();
+    return res.json(qs);
+  }
+  res.json(memory);
+});
+
+// Create or update a quote
+router.post('/', async (req, res) => {
+  const { id, client, project, value, status, date, items } = req.body || {};
+  if (!(id && client && project && date && Array.isArray(items))) {
+    return res.status(400).json({ message: 'Missing required fields' });
+  }
+
+  try {
+    if (process.env.CONNECTION_STRING) {
+      const doc = await Quote.findOneAndUpdate(
+        { id },
+        { id, client, project, value, status, date, items },
+        { upsert: true, new: true }
+      );
+      return res.status(201).json(doc);
+    }
+    const idx = memory.findIndex(q => q.id === id);
+    const data = { id, client, project, value, status, date, items };
+    if (idx >= 0) memory[idx] = data; else memory.push(data);
+    res.status(201).json(data);
+  } catch (err) {
+    res.status(400).json({ message: err.message });
+  }
+});
+
+// Get single quote
+router.get('/:id', async (req, res) => {
+  const { id } = req.params;
+  if (process.env.CONNECTION_STRING) {
+    const doc = await Quote.findOne({ id }).lean();
+    if (!doc) return res.status(404).json({ message: 'Not found' });
+    return res.json(doc);
+  }
+  const q = memory.find(q => q.id === id);
+  if (!q) return res.status(404).json({ message: 'Not found' });
+  res.json(q);
+});
+
+// Delete quote
+router.delete('/:id', async (req, res) => {
+  const { id } = req.params;
+  if (process.env.CONNECTION_STRING) {
+    await Quote.findOneAndDelete({ id });
+    return res.json({ message: 'Deleted' });
+  }
+  const idx = memory.findIndex(q => q.id === id);
+  if (idx === -1) return res.status(404).json({ message: 'Not found' });
+  memory.splice(idx, 1);
+  res.json({ message: 'Deleted' });
+});
+
+export default router;

--- a/client/lib/project-store.ts
+++ b/client/lib/project-store.ts
@@ -19,6 +19,8 @@ export interface Project {
 
 const KEY = 'projects'
 const base = process.env.NEXT_PUBLIC_API_URL ?? ''
+// Use dedicated quotes endpoint on the backend
+const QUOTE_URL = `${base}/api/quotes`
 
 function getToken(): string | null {
   if (typeof localStorage === 'undefined') return null
@@ -37,7 +39,7 @@ export async function loadProjects(): Promise<Project[]> {
     const headers: Record<string, string> = {}
     const token = getToken()
     if (token) headers['Authorization'] = `Bearer ${token}`
-    const res = await fetch(`${base}/api/projects`, { cache: 'no-store', headers })
+    const res = await fetch(QUOTE_URL, { cache: 'no-store', headers })
     if (res.ok) {
       const data = (await res.json()) as Project[]
       if (typeof localStorage !== 'undefined') {
@@ -64,7 +66,7 @@ export async function saveProject(q: Project) {
     const headers: Record<string, string> = { 'Content-Type': 'application/json' }
     const token = getToken()
     if (token) headers['Authorization'] = `Bearer ${token}`
-    const res = await fetch(`${base}/api/projects`, {
+    const res = await fetch(QUOTE_URL, {
       method: 'POST',
       headers,
       body: JSON.stringify(q),
@@ -86,7 +88,7 @@ export async function getProject(id: string): Promise<Project | undefined> {
     const headers: Record<string, string> = {}
     const token = getToken()
     if (token) headers['Authorization'] = `Bearer ${token}`
-    const res = await fetch(`${base}/api/projects/${id}`, { cache: 'no-store', headers })
+    const res = await fetch(`${QUOTE_URL}/${id}`, { cache: 'no-store', headers })
     if (res.ok) {
       const q = (await res.json()) as Project
       if (typeof localStorage !== 'undefined') {
@@ -112,7 +114,7 @@ export async function deleteProject(id: string) {
     const headers: Record<string, string> = {}
     const token = getToken()
     if (token) headers['Authorization'] = `Bearer ${token}`
-    const res = await fetch(`${base}/api/projects/${id}`, { method: 'DELETE', headers })
+    const res = await fetch(`${QUOTE_URL}/${id}`, { method: 'DELETE', headers })
     console.log('deleteProject status', res.status)
   } catch {
     // ignore


### PR DESCRIPTION
## Summary
- add `Quote` model for storing pricing results
- create `/api/quotes` endpoints for CRUD operations
- expose the new route in the Express app
- adjust client project store to use `/api/quotes`

## Testing
- `npm -C backend test` *(fails: ERR_ASSERTION)*

------
https://chatgpt.com/codex/tasks/task_b_684c5c5967688325909adeb12be5e020